### PR TITLE
ci: build docker on all commits

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,10 +1,8 @@
+---
 name: Docker Build
 
 on:
   push:
-    branches:
-      - main
-      - master
 
 env:
   IMAGE_NAME: vatsim-scandinavia/discord-bot


### PR DESCRIPTION
Should be merged before #113. Fixes a specific problem where changes
could break builds without us finding out until after it has been
merged. We can still do that in other ways, but it should be harder to
break the Docker build without noticing.
