### PR TITLE
refactor: split staffing messaging into module

### DIFF
--- a/cogs/staffings.py
+++ b/cogs/staffings.py
@@ -15,6 +15,7 @@ from helpers.db import DB
 from helpers.select import SelectView
 from helpers.config import config
 from helpers.handler import Handler
+import helpers.staffings.messages as ask
 
 class StaffingCog(commands.Cog):
     #
@@ -25,7 +26,7 @@ class StaffingCog(commands.Cog):
     def __init__(self, bot) -> None:
         self.bot = bot
         self.autoreset.start()
-        self.staffing_async = StaffingAsync()
+        self.staffing_async = StaffingAsync(base_url=config.EVENT_CALENDAR_URL, calendar_type=config.EVENT_CALENDAR_TYPE, token=config.CC_API_TOKEN)
 
     def cog_unload(self):
         self.autoreset.cancel()
@@ -67,12 +68,12 @@ class StaffingCog(commands.Cog):
     async def setup_staffing(self, interaction: Interaction, title: str, week_int: app_commands.Range[int, 1, 4], section_amount: app_commands.Range[int, 1, 4], restrict_booking: Literal["Yes", "No"], channel: TextChannel):
         ctx = await Handler.get_context(self, self.bot, interaction)
         dates = await self.staffing_async._geteventdate(title)
-        description = await self.staffing_async._get_description(self.bot, ctx)
+        description = await ask.get_description(self.bot, ctx)
         description = description + "\n\nTo book a position, write `/book`, press TAB and then write the callsign.\nTo unbook a position, use `/unbook`."
         i = 1
         section_positions = {}
         for _ in range(section_amount):
-            section_title = await self.staffing_async._setup_section(self.bot, ctx, i)
+            section_title = await ask.setup_section(self.bot, ctx, i)
             section_pos = await self.staffing_async._setup_section_pos(self.bot, ctx, section_title)
             section_positions[section_title] = section_pos
             i += 1

--- a/helpers/staffings/messages.py
+++ b/helpers/staffings/messages.py
@@ -1,0 +1,155 @@
+# messages.py
+
+async def get_description(bot, ctx):
+    """Get the description of the event from a message."""
+    try:
+        await ctx.send('Staffing message? **FYI this command expires in 5 minutes**')
+        message = await bot.wait_for('message', timeout=300, check=lambda message: message.author == ctx.author and ctx.channel == message.channel)
+
+        if len(message.content) < 1:
+            await ctx.send('Setup cancelled. No message was provided.')
+            raise ValueError
+
+        return message.content
+    except Exception as e:
+        await ctx.send(f'Error getting the Staffing message - {e}')
+        raise e
+
+async def get_interval(bot, ctx):
+    """Get the week interval of the event."""
+    try:
+        await ctx.send('Week interval? **FYI this command expires in 5 minutes**')
+        message = await bot.wait_for('message', timeout=300, check=lambda message: message.author == ctx.author and ctx.channel == message.channel)
+
+        if len(message.content) < 1:
+            await ctx.send('Setup cancelled. No message was provided.')
+            raise ValueError
+
+        if int(message.content) not in range(1, 5):
+            await ctx.send('The interval must be between 1 to 4')
+            raise ValueError
+
+        return message.content
+    except Exception as e:
+        await ctx.send(f'Error getting the Staffing message - {e}')
+        raise e
+
+async def get_restriction(bot, ctx):
+    """Get the booking restriction of the event."""
+    try:
+        await ctx.send('Should the event have booking restriction? Allowed ansers: `Yes` or `No` **FYI this command expires in 5 minutes**')
+        message = await bot.wait_for('message', timeout=300, check=lambda message: message.author == ctx.author and ctx.channel == message.channel)
+
+        if len(message.content) < 1:
+            await ctx.send('Setup cancelled. No message was provided.')
+            raise ValueError
+
+        if 'yes' in message.content.lower() or 'no' in message.content.lower():
+            return message.content.lower()
+        else:
+            await ctx.send('Only the options `Yes` or `No` is available')
+            raise ValueError
+            
+    except Exception as e:
+        await ctx.send(f'Error getting the Staffing message - {e}')
+        raise e
+
+async def setup_section(bot, ctx, num: int):
+    """Get the title for positions of the event."""
+    try:
+        await ctx.send(f'Section title nr. {num}? **FYI this command expires in 1 minute**')
+        message = await bot.wait_for('message', timeout=60, check=lambda message: message.author == ctx.author and ctx.channel == message.channel)
+
+        if len(message.content) < 1:
+            await ctx.send('Setup cancelled. No message was provided.')
+            raise ValueError
+
+        return message.content
+
+    except Exception as e:
+        await ctx.send(f'Error getting the third section title - {e}')
+        raise e
+
+async def get_howmanypositions(bot, ctx, type):
+    """Get how many positions of the event."""
+    try:
+        await ctx.send(f'How many {type} positions? **FYI this command expires in 1 minute**')
+        message = await bot.wait_for('message', timeout=60, check=lambda message: message.author == ctx.author and ctx.channel == message.channel)
+
+        if len(message.content) < 1:
+            await ctx.send('Setup cancelled. No message was provided.')
+            raise ValueError
+
+        return message.content
+    except Exception as e:
+        await ctx.send(f'Error getting amount of positions - {e}')
+        raise e
+
+async def section_type(bot, ctx):
+    """Get what type of section to update."""
+    try:
+        await ctx.send(f'Which section would you like to update?**FYI this command expires in 1 minute** \nAvailable sections is: `1, 2 or 3`')
+        message = await bot.wait_for('message', timeout=60, check=lambda message: message.author == ctx.author and ctx.channel == message.channel)
+
+        if len(message.content) < 1:
+            await ctx.send('Setup cancelled. No message was provided.')
+            raise ValueError
+
+        if int(message.content) not in range(1, 4):
+            await ctx.send('The section must be between 1 to 3')
+            raise ValueError
+
+        return message.content
+
+    except Exception as e:
+        await ctx.send(f'Error getting the section title - {e}')
+        raise e
+
+async def get_start_or_end_time(bot, ctx, time):
+    """Get the start or end time."""
+    try:
+        await ctx.send(f'Does this position have a specified {time}? If yes, then insert below (format: `HH:MM`), otherwise type `No`! **FYI this command expires in 1 minute**')
+
+        message = await bot.wait_for('message', timeout=60, check=lambda message: message.author == ctx.author and ctx.channel == message.channel)
+
+        if len(message.content) < 1:
+            await ctx.send('Setup cancelled. No message was provided.')
+            raise ValueError       
+
+        if 'no' in message.content.lower():
+            return None
+
+        return message.content
+    
+    except Exception as e:
+        await ctx.send(f'Error getting the {time} - {e}')
+        raise e
+
+async def get_local_booking(bot, ctx):
+    try:
+        await ctx.send(f'Is this positions a local position? Allowed ansers: `Yes` or `No` **FYI this command expires in 1 minutes**')
+
+        message = await bot.wait_for('message', timeout=60, check=lambda message: message.author == ctx.author and ctx.channel == message.channel)
+
+        if 'yes' in message.content.lower() or 'no' in message.content.lower():
+            return True if message.content.lower() == 'yes' else False
+        else:
+            await ctx.send('Only the options `Yes` or `No` is available')
+            raise ValueError
+            
+    except Exception as e:
+        await ctx.send(f'Error getting the local booking option - {e}')
+        raise e
+
+async def get_confirmation(bot, ctx, title):
+    try:
+        await ctx.send(f'To confirm you want to delete staffing {title} type `{title}` in the chat. If you want to cancel the deletion type `CANCEL` in the chat. **FYI this command expires in 1 minute**')
+        message = await bot.wait_for('message', timeout=60, check=lambda message: message.author == ctx.author and ctx.channel == message.channel)
+
+        if len(message.content) < 1:
+            await ctx.send('Deletion cancelled. No message was provided.')
+            raise ValueError
+
+        return message.content
+    except Exception as e:
+        await ctx.send(f'Error getting message - {e}')

--- a/services/events.py
+++ b/services/events.py
@@ -1,0 +1,67 @@
+import aiohttp
+from typing import List, Dict, Any, Optional
+
+class EventService:
+    def __init__(self, *, base_url: str, calendar_type: str, token: str):
+        self.base_url = base_url
+        self.calendar_type = calendar_type
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json"
+        }
+
+    async def _fetch_data(self, endpoint: str, params: Optional[dict] = None) -> Optional[List[Any]]:
+        """
+        Generic method to fetch data from the API.
+
+        Args:
+            endpoint (str): The API endpoint to query.
+            params (dict, optional): Query parameters to include in the request.
+
+        Returns:
+            Optional[List[Any]]: The parsed JSON response data or None if the request fails.
+        """
+        url = f"{self.base_url}/{endpoint}"
+
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.get(url, headers=self.headers, params=params) as response:
+                    response.raise_for_status()
+                    resp = await response.json()
+                    data = resp.get("data", [])
+                    if data:
+                        return data
+                    
+                    return resp
+            except aiohttp.ClientError as e:
+                print(f"HTTP error occurred while accessing {url}: {e}")
+                return None
+
+    async def get_calendar_events(self) -> List[Dict[str, Any]]:
+        """Get all events from a specific calendar"""
+        return await self._fetch_data(f"calendars/{self.calendar_type}/events")
+
+    async def get_event_titles(self, exclude_titles: List[str] = None) -> List[str]:
+        """Get list of unique event titles, optionally excluding specific titles"""
+        events = await self.get_calendar_events()
+        if not events:
+            return ['None is available. Please try again later.']
+
+        titles = []
+        exclude_titles = set(exclude_titles or [])
+        
+        for event in events:
+            title = str(event.get('title', ''))
+            if title and title not in exclude_titles:
+                titles.append(title)
+
+        return list(set(titles))
+
+    async def get_event_details(self, title: str) -> Optional[Dict[str, Any]]:
+        """Get details for a specific event by title"""
+        events = await self.get_calendar_events()
+        if not events:
+            return None
+        
+        return next((event for event in events if event.get("title") == title), None)
+


### PR DESCRIPTION
Despite the work to move staffings and events entirely out of the
Discord bot, this commit tries to help make the code more readable by
splitting the jobs into different areas of concern. This is not
complete, but does a first stab at getting started with these areas:

- Move messages between the bot and users for staffings into a separate
  module, `helpers.staffings.messages`.

- Move away all non-instance related methods into a package rather than
  keeping it in a class.

- Keep staffing-related elements in the StaffingAsync module.

- Move away event-related instances into a separate event service.

These changes should have no functional changes.
