### PR TITLE
feat: initial coordination cog

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -247,6 +247,7 @@ signal.signal(signal.SIGTERM, handle_exit_signal)  # For termination signal
 # Start the bot
 if __name__ == '__main__':
     try:
+        discord.utils.setup_logging()
         bot.run(config.BOT_TOKEN)
     except Exception as e:
         print(f'Error starting the bot. Exception - {e}', flush=True)

--- a/cogs/coordination.py
+++ b/cogs/coordination.py
@@ -159,6 +159,10 @@ class CoordinationCog(commands.Cog):
                 await self._restore_nickname(member)
                 return
 
+            # If there's no prefix, then there's nothing to do
+            if not prefix:
+                return
+
             # Add the prefix to the user and and store original nickname before modification
             _create_task(self._member_cache.store_nickname(member.id, current_nick))
             new_name_candidate = self._format_name(prefix, name, cid)

--- a/cogs/coordination.py
+++ b/cogs/coordination.py
@@ -184,7 +184,7 @@ class CoordinationCog(commands.Cog):
                 tasks.extend(
                     [self._update_member_nickname(member) for member in channel.members]
                 )
-        await asyncio.gather(*tasks)
+        _create_task(*tasks)
 
     @commands.Cog.listener()
     async def on_voice_state_update(

--- a/cogs/coordination.py
+++ b/cogs/coordination.py
@@ -189,13 +189,13 @@ class CoordinationCog(commands.Cog):
                 return
 
             callsign = await self._get_controller_station(cid)
-            if not self._feature_enabled(cid, callsign):
-                return
-
             modified_member = self._member_cache.get(member.id)
             if modified_member and not callsign:
                 # Modified members without callsigns should be restored
                 await self._restore_nickname(member)
+                return
+
+            if not self._feature_enabled(cid, callsign):
                 return
 
             if not callsign:

--- a/cogs/coordination.py
+++ b/cogs/coordination.py
@@ -34,6 +34,13 @@ class MemberNickUpdateException(Exception):
     """Failed to update the nickname of a member."""
 
 
+class NewNickTooLongException(Exception):
+    """New nickname exceeds the maximum length."""
+
+    def __init__(self, nick: str):
+        super().__init__(f'New nickname exceeds 32 characters: {nick}')
+
+
 class CoordinationCog(commands.Cog):
     """
     A cog for exposing VATSIM controller status in Discord voice channels.
@@ -244,7 +251,7 @@ class CoordinationCog(commands.Cog):
             new_name = self._format_name(callsign, short_name, cid)
 
         if len(new_name) > 32:
-            raise ValueError(f'New name exceeds 32 characters: {new_name}')
+            raise NewNickTooLongException(new_name)
 
         logger.info(
             'Updating nickname',

--- a/cogs/coordination.py
+++ b/cogs/coordination.py
@@ -162,8 +162,10 @@ class CoordinationCog(commands.Cog):
         if cid in self._allowed_cids:
             return True
 
-        if self._allowed_callsigns_pattern and re.match(
-            self._allowed_callsigns_pattern, callsign
+        if (
+            callsign
+            and self._allowed_callsigns_pattern
+            and re.match(self._allowed_callsigns_pattern, callsign)
         ):
             return True
 

--- a/cogs/coordination.py
+++ b/cogs/coordination.py
@@ -195,11 +195,11 @@ class CoordinationCog(commands.Cog):
                 await self._restore_nickname(member)
                 return
 
-            if not self._feature_enabled(cid, callsign):
-                return
-
             if not callsign:
                 # If there's no callsign, then there's nothing to do
+                return
+
+            if not self._feature_enabled(cid, callsign):
                 return
 
             # Add the prefix to the user and and store original nickname before modification
@@ -259,15 +259,17 @@ class CoordinationCog(commands.Cog):
         after: discord.VoiceState,
     ):
         """Handle voice state changes to update nicknames"""
-        if before.channel == after.channel:
+        if before.channel and after.channel:
+            # The user is still connected to a voice channel
             return
 
-        if after.channel is None:
-            # User left voice voice channels altogether
-            await self._update_member_nickname(member, force_remove=True)
-        else:
-            # The user moved to a different voice channel
+        if after.channel:
+            # The user joined a new voice channel, doesn't matter which
             await self._update_member_nickname(member)
+            return
+
+        # User left voice voice channels altogether
+        await self._update_member_nickname(member, force_remove=True)
 
     @app_commands.command(
         name='updatevoice', description='Update voice channel member nicknames'

--- a/cogs/coordination.py
+++ b/cogs/coordination.py
@@ -108,7 +108,7 @@ class CoordinationCog(commands.Cog):
             # TODO(thor): consider splitting into a separate background task
             await self._update_voice_channel_members()
         except Exception as e:
-            logger.exception(f'Failed to update controllers cache: {e}')
+            logger.exception(f'Failed to update controllers cache')
 
     async def _get_controller_station(self, cid: int) -> Optional[str]:
         """Get the controller's prefix if they're online, None otherwise"""
@@ -178,7 +178,7 @@ class CoordinationCog(commands.Cog):
         except discord.Forbidden:
             logger.warning(f'Bot lacks permission to change nickname of {member}')
         except Exception as e:
-            logger.exception(f'Error updating nickname for {member}: {e}')
+            logger.exception(f'Error updating nickname for {member}')
 
     async def _update_voice_channel_members(self):
         """Update all members in voice channels across all guilds"""
@@ -221,7 +221,7 @@ class CoordinationCog(commands.Cog):
                 'Voice channel nicknames updated.', ephemeral=True
             )
         except Exception as e:
-            logger.exception(f'Error in update_voice command: {e}')
+            logger.exception(f'Error in update_voice command')
             await interaction.followup.send(
                 'An error occurred while updating nicknames.', ephemeral=True
             )

--- a/cogs/coordination.py
+++ b/cogs/coordination.py
@@ -1,0 +1,249 @@
+import asyncio
+import datetime
+import logging
+from collections.abc import Coroutine
+from typing import Optional
+
+import aiohttp
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from helpers.config import config
+from helpers.handler import Handler
+from helpers.member_cache import MemberCache
+
+logger = logging.getLogger(__name__)
+
+VATSIM_BASE_URL = 'https://data.vatsim.net'
+VATSIM_DATA = '/v3/vatsim-data.json'
+
+
+class VATSIMDataFetchException(Exception):
+    """Custom exception for VATSIM data fetch errors."""
+
+    status_code: int
+
+    def __init__(self, response: aiohttp.ClientResponse):
+        self.status_code = response.status
+        super().__init__(f'Failed to fetch VATSIM data: HTTP {self.status_code}')
+
+
+class CoordinationCog(commands.Cog):
+    """
+    A cog for exposing VATSIM controller status in Discord voice channels.
+    This cog handles the synchronization between VATSIM controller status and Discord voice channel
+    member nicknames. It periodically fetches online controller data from VATSIM and updates
+    Discord member nicknames to reflect their controlling status when they join/leave voice channels.
+
+    Commands:
+        updatevoice: Manually trigger nickname updates for all voice channel members
+
+    Events:
+        on_voice_state_update: Handles nickname updates when members join/leave voice channels
+
+    Tasks:
+        update_controllers_cache: Periodic task to refresh online controller data
+
+    Note:
+        Requires appropriate Discord permissions to modify member nicknames
+        Relies on VATSIM Datafeed API for controller status data
+
+    """
+
+    def __init__(self, bot: commands.Bot):
+        self._bot = bot
+        self._handler = Handler()
+        self._last_update: datetime.datetime = None
+        self._session = aiohttp.ClientSession(base_url=VATSIM_BASE_URL)
+        self._online_controllers: dict[str, str] = {}
+        self._member_cache = MemberCache(folder=config.CACHE_DIR)
+        self._update_controllers_cache.start()
+        # TODO(thor): remove this allow list after validation
+        self._allowed_cids = config.COORDINATION_ALLOWED_CIDS
+        logger.info('Initialized and started updating controllers cache')
+
+    async def cog_unload(self):
+        self._update_controllers_cache.cancel()
+        await self._session.close()
+        await self._clean_up()
+        logger.info('Stopped updating cache and attempted restoring existing members')
+
+    async def _clean_up(self):
+        ids = self._member_cache.get_member_ids()
+        members = self._bot.get_all_members()
+        tasks = [
+            self._update_member_nickname(member=member, force_remove=True)
+            for member in members
+            if member.id in ids
+        ]
+        _create_task(*tasks)
+
+    async def _fetch_online_controllers(self) -> dict[int, str]:
+        """Fetch online controllers from VATSIM Datafeed API"""
+        try:
+            async with self._session.get(VATSIM_DATA) as response:
+                if response.status != 200:
+                    raise VATSIMDataFetchException(response)
+                data = await response.json()
+            controllers = {}
+            for controller in data.get('controllers', []):
+                if controller.get('facility') != 0:
+                    cid = int(controller.get('cid'))
+                    controllers[cid] = controller.get('callsign')
+            return controllers
+        except VATSIMDataFetchException:
+            raise
+        except Exception:
+            logger.exception('Failed to fetch online controllers')
+            return {}
+
+    @tasks.loop(minutes=1, reconnect=True)
+    async def _update_controllers_cache(self):
+        """Update the cache of online controllers periodically"""
+        try:
+            logger.debug('Updating online controllers cache...')
+            self._online_controllers = await self._fetch_online_controllers()
+            self._last_update = datetime.datetime.now()
+            # TODO(thor): consider splitting into a separate background task
+            await self._update_voice_channel_members()
+        except Exception as e:
+            logger.exception(f'Failed to update controllers cache: {e}')
+
+    async def _get_controller_station(self, cid: int) -> Optional[str]:
+        """Get the controller's prefix if they're online, None otherwise"""
+        if cid in self._online_controllers:
+            return self._online_controllers[cid].replace('__', '_')
+        return None
+
+    async def _restore_nickname(self, member: discord.Member) -> None:
+        """Restore the original nickname of a member"""
+        original_nick = self._member_cache.get_nickname(member.id)
+        if not original_nick:
+            logger.warning('Original nickname not found', extra={member: member})
+            return
+
+        # Remove the nickname first to avoid issue for those weird users who have higher permissions
+        # than the bot itself. This is an additional risk, but one we're fine to make.
+        _create_task(self._member_cache.remove_nickname(member.id))
+        await member.edit(
+            nick=original_nick,
+            reason='Removing callsign prefix after leaving voice channel',
+        )
+
+    def _format_name(self, prefix: str, name: str, cid: int) -> str:
+        return f'{prefix}: {name} - {cid}'
+
+    async def _update_member_nickname(
+        self, member: discord.Member, force_remove: bool = False
+    ) -> None:
+        """Update member's nickname based on their controlling station"""
+        try:
+            if not member.voice or force_remove:
+                await self._restore_nickname(member)
+                return
+
+            cid = await self._handler.get_cid(member)
+            name = self._handler.get_name(member)
+            if not cid or not name:
+                return
+
+            # TODO(thor): remove after validation
+            if cid not in self._allowed_cids:
+                logger.info(f"Skipping CID {cid} as it's not in {self._allowed_cids}")
+                return
+
+            current_nick = member.nick or member.name
+            prefix = await self._get_controller_station(cid)
+            if not prefix and ':' in current_nick:
+                await self._restore_nickname(member)
+                return
+
+            # Add the prefix to the user and and store original nickname before modification
+            _create_task(self._member_cache.store_nickname(member.id, current_nick))
+            new_name_candidate = self._format_name(prefix, name, cid)
+            max_length = max(0, len(name) - (len(new_name_candidate) - 32))
+            short_name = _ellipsify(name, max_length)
+            new_name = self._format_name(prefix, short_name, cid)
+            await member.edit(
+                nick=new_name[:32],
+                reason='Adding callsign prefix after joining voice channel',
+            )
+            logger.info(f'Updating nickname for {member} to {new_name=}')
+
+        except discord.Forbidden:
+            logger.warning(f'Bot lacks permission to change nickname of {member}')
+        except Exception as e:
+            logger.exception(f'Error updating nickname for {member}: {e}')
+
+    async def _update_voice_channel_members(self):
+        """Update all members in voice channels across all guilds"""
+        tasks = []
+        for guild in self._bot.guilds:
+            for channel in guild.voice_channels:
+                tasks.extend(
+                    [self._update_member_nickname(member) for member in channel.members]
+                )
+        await asyncio.gather(*tasks)
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(
+        self,
+        member: discord.Member,
+        before: discord.VoiceState,
+        after: discord.VoiceState,
+    ):
+        """Handle voice state changes to update nicknames"""
+        if before.channel == after.channel:
+            return
+
+        if after.channel is None:
+            # User left voice voice channels altogether
+            await self._update_member_nickname(member, force_remove=True)
+        else:
+            # The user moved to a different voice channel
+            await self._update_member_nickname(member)
+
+    @app_commands.command(
+        name='updatevoice', description='Update voice channel member nicknames'
+    )
+    @app_commands.checks.has_any_role(*config.STAFF_ROLES)
+    async def update_voice(self, interaction: discord.Interaction):
+        """Manually update all voice channel member nicknames"""
+        try:
+            await interaction.response.defer(ephemeral=True)
+            await self._update_voice_channel_members()
+            await interaction.followup.send(
+                'Voice channel nicknames updated.', ephemeral=True
+            )
+        except Exception as e:
+            logger.exception(f'Error in update_voice command: {e}')
+            await interaction.followup.send(
+                'An error occurred while updating nicknames.', ephemeral=True
+            )
+
+
+async def setup(bot):
+    await bot.add_cog(CoordinationCog(bot))
+
+
+_background_tasks = set()
+
+
+def _create_task(*coroutines: Coroutine):
+    """Decorator to run a function in the background without waiting for it to finish"""
+    for coroutine in coroutines:
+        task = asyncio.create_task(coroutine)
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+
+
+def _ellipsify(needle: str, max_length: int) -> str:
+    """Shorten needle to fit within max_length characters"""
+    if len(needle) > max_length:
+        shortened = needle[: max_length - 1]
+        # Remove trailing space if present
+        if shortened[-1].isspace():
+            shortened = shortened[:-1]
+        return shortened + '…'
+    return needle

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -1,6 +1,6 @@
 import os
-from pathlib import Path
 from distutils.util import strtobool
+from pathlib import Path
 
 import discord
 import discord.ext
@@ -202,6 +202,11 @@ class Config:
         self.BOT_DB_USER = str(os.getenv('BOT_DB_USER', ''))
         self.BOT_DB_PASSWORD = str(os.getenv('BOT_DB_PASSWORD', ''))
         self.BOT_DB_NAME = str(os.getenv('BOT_DB_NAME', ''))
+
+        # Coordination
+        self.COORDINATION_ALLOWED_CIDS = set(
+            map(int, filter(None, os.getenv('COORDINATION_ALLOWED_CIDS', '').split(',')))
+        )
 
     def activity(self) -> discord.Activity:
         return discord.Activity(

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -205,7 +205,12 @@ class Config:
 
         # Coordination
         self.COORDINATION_ALLOWED_CIDS = set(
-            map(int, filter(None, os.getenv('COORDINATION_ALLOWED_CIDS', '').split(',')))
+            map(
+                int, filter(None, os.getenv('COORDINATION_ALLOWED_CIDS', '').split(','))
+            )
+        )
+        self.COORDINATION_ALLOWED_CALLSIGNS = os.getenv(
+            'COORDINATION_ALLOWED_CALLSIGNS', ''
         )
 
     def activity(self) -> discord.Activity:

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from distutils.util import strtobool
 
 import discord
@@ -16,6 +17,8 @@ class Config:
         self.BOT_TOKEN = os.getenv('BOT_TOKEN', '')
         self.GUILD_ID = int(os.getenv('GUILD_ID', 0))
         self.DEBUG = bool(strtobool(os.getenv('DEBUG', 'False')))
+        self.CACHE_DIR = Path(os.getenv('CACHE_DIR', '/var/cache/discord-bot'))
+        """The cache directory is used to store cached data for the bot"""
 
         self.PREFIX = '/'
         self.VATSCA_BLUE = 0x43C6E7
@@ -26,6 +29,7 @@ class Config:
         # Cogs and admin roles
         self.COGS = [
             'cogs.admin',
+            'cogs.coordination',
             'cogs.fastapi',
             'cogs.member',
             'cogs.publisher',
@@ -37,6 +41,7 @@ class Config:
 
         self.COGS_LOAD = {
             'admin': 'cogs.admin',
+            'coordination': 'cogs.coordination',
             'fastapi': 'cogs.fastapi',
             'member': 'cogs.member',
             'publisher': 'cogs.publisher',

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -210,7 +210,7 @@ class Config:
             )
         )
         self.COORDINATION_ALLOWED_CALLSIGNS = os.getenv(
-            'COORDINATION_ALLOWED_CALLSIGNS', ''
+            'COORDINATION_ALLOWED_CALLSIGNS', '(?!.*)'
         )
 
     def activity(self) -> discord.Activity:

--- a/helpers/handler.py
+++ b/helpers/handler.py
@@ -94,17 +94,31 @@ class Handler:
 
             return data, next_url
 
-    async def get_cid(self, user):
+    async def get_cid(self, member: discord.Member):
         """
-        Get CID based on user discord ID.
+        Get CID based on VATSIM Discord member.
 
         Args:
-            user (discord.Member): The Discord member object.
+            member: The Discord guild member.
 
         """
-        cid = re.findall(r'\d+', str(user.nick))
+        cid = re.findall(r'\d+', str(member.nick))
 
         if len(cid) < 1:
             raise ValueError
 
         return int(cid[0])
+
+    def get_name(self, member: discord.Member):
+        """
+        Get presentation name based on VATSIM Discord member.
+
+        Args:
+            member: The Discord guild member.
+
+        """
+        name = re.findall(r'.+?(?= -)', str(member.nick))
+        if not name:
+            raise ValueError
+
+        return name[0]

--- a/helpers/handler.py
+++ b/helpers/handler.py
@@ -119,6 +119,6 @@ class Handler:
         """
         name = re.findall(r'.+?(?= -)', str(member.nick))
         if not name:
-            raise ValueError
+            return None
 
         return name[0]

--- a/helpers/member_cache.py
+++ b/helpers/member_cache.py
@@ -1,0 +1,61 @@
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+import aiofiles
+
+logger = logging.getLogger(__name__)
+
+class MemberCache:
+    """
+    Possibly unsafe member cache for storing original nicknames of members.
+
+    Should be sort of thread-safe with asyncio.Lock.
+    """
+
+    def __init__(self, folder: Path, file: str = "member_cache.json"):
+        self._cache_file = folder.joinpath(file)
+        self._nicknames: dict[str, str] = {}
+        self._lock = asyncio.Lock()
+        self._load_cache()
+
+    def _load_cache(self) -> None:
+        """Load nickname cache from file"""
+        try:
+            if self._cache_file.exists():
+                with open(self._cache_file) as f:
+                    self._nicknames = json.load(f)
+        except Exception as e:
+            logger.exception(f"Failed to load nickname cache: {e}")
+            self._nicknames = {}
+
+    async def _save_cache(self) -> None:
+        """Save nickname cache to file"""
+        try:
+            async with aiofiles.open(self._cache_file, 'w') as f:
+                await f.write(json.dumps(self._nicknames))
+        except Exception as e:
+            logger.exception(f"Failed to save nickname cache: {e}")
+
+    async def store_nickname(self, member_id: int, nickname: str) -> None:
+        """Store original nickname for a member"""
+        async with self._lock:
+            self._nicknames[str(member_id)] = nickname
+            await self._save_cache()
+
+    def get_nickname(self, member_id: int) -> Optional[str]:
+        """Retrieve original nickname for a member"""
+        return self._nicknames.get(str(member_id))
+
+    def get_member_ids(self) -> list[int]:
+        """Get all member IDs in the cache"""
+        return [int(member_id) for member_id in self._nicknames]
+
+    async def remove_nickname(self, member_id: int) -> None:
+        """Remove nickname from cache"""
+        async with self._lock:
+            if str(member_id) in self._nicknames:
+                del self._nicknames[str(member_id)]
+                await self._save_cache()

--- a/helpers/member_cache.py
+++ b/helpers/member_cache.py
@@ -49,7 +49,9 @@ class MemberCache:
         except Exception:
             self._log.exception('Failed to save nickname cache')
 
-    async def store(self, member_id: int, nick: str, name: Optional[str], cid: int) -> None:
+    async def store(
+        self, member_id: int, nick: str, name: Optional[str], cid: int
+    ) -> None:
         """Store original nickname for a member"""
         async with self._lock:
             self._nicknames[str(member_id)] = MemberNick(name=name, nick=nick, cid=cid)

--- a/helpers/member_cache.py
+++ b/helpers/member_cache.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class MemberNick(TypedDict):
     """Cached member information"""
 
-    name: str
+    name: Optional[str]
     nick: str
     cid: int
 
@@ -48,7 +48,7 @@ class MemberCache:
         except Exception as e:
             logger.exception(f'Failed to save nickname cache: {e}')
 
-    async def store(self, member_id: int, nick: str, name: str, cid: int) -> None:
+    async def store(self, member_id: int, nick: str, name: Optional[str], cid: int) -> None:
         """Store original nickname for a member"""
         async with self._lock:
             self._nicknames[str(member_id)] = MemberNick(name=name, nick=nick, cid=cid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "fastapi==0.115.8",
     "python-multipart==0.0.20",
     "aiofiles>=24.1.0",
+    "structlog>=25.2.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "uvicorn==0.34.0",
     "fastapi==0.115.8",
     "python-multipart==0.0.20",
+    "aiofiles>=24.1.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ ignore = [
     "D203", "D211", "D212", "COM812", "Q000", "Q003", "E501",
     "ANN", # type annotations missing
     "FA100", # future rewritable type is fine to ignore
+    "FIX", # todos, fixmes, etc. are useful
+    "TD003", # We don't need a link for all todos, they're future context
     # TODO: list of ignored errors we must fix
     "T201",
     "D102",

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "24.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896 },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -334,6 +343,7 @@ name = "discord-bot"
 version = "2.0.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "aiofiles" },
     { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
     { name = "discord" },
     { name = "discord-py" },
@@ -361,6 +371,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2.1" },
     { name = "discord", specifier = "==1.7.3" },
     { name = "discord-py", specifier = "==2.4.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -359,6 +359,7 @@ dependencies = [
     { name = "requests" },
     { name = "sentry-sdk" },
     { name = "setuptools" },
+    { name = "structlog" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
     { name = "websockets" },
@@ -387,6 +388,7 @@ requires-dist = [
     { name = "requests", specifier = "==2.32.3" },
     { name = "sentry-sdk", specifier = "==2.13.0" },
     { name = "setuptools", specifier = "==74.1.2" },
+    { name = "structlog", specifier = ">=25.2.0" },
     { name = "typing-extensions", specifier = "==4.12.2" },
     { name = "uvicorn", specifier = "==0.34.0" },
     { name = "websockets", specifier = "==13.0.1" },
@@ -1006,6 +1008,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ff/fb/2984a686808b89a6781526129a4b51266f678b2d2b97ab2d325e56116df8/starlette-0.45.3.tar.gz", hash = "sha256:2cbcba2a75806f8a41c722141486f37c28e30a0921c5f6fe4346cb0dcee1302f", size = 2574076 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/61/f2b52e107b1fc8944b33ef56bf6ac4ebbe16d91b94d2b87ce013bf63fb84/starlette-0.45.3-py3-none-any.whl", hash = "sha256:dfb6d332576f136ec740296c7e8bb8c8a7125044e7c6da30744718880cdd059d", size = 71507 },
+]
+
+[[package]]
+name = "structlog"
+version = "25.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b8/d3670aec25747e32d54cd5258102ae0d69b9c61c79e7aa326be61a570d0d/structlog-25.2.0.tar.gz", hash = "sha256:d9f9776944207d1035b8b26072b9b140c63702fd7aa57c2f85d28ab701bd8e92", size = 1367438 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/eb/244741c1abf7b4092686db0798a4c43491298f40ddec4226f5c4f6b5d3eb/structlog-25.2.0-py3-none-any.whl", hash = "sha256:0fecea2e345d5d491b72f3db2e5fcd6393abfc8cd06a4851f21fcd4d1a99f437", size = 68448 },
 ]
 
 [[package]]


### PR DESCRIPTION
Introduce a coordination cog that includes a member cache for storing original nicknames, providing controllers with the power to see which stations specific members are controlling by looking at their callsign. Adds a prefix to controllers' nicknames in Discord.

See #122 for follow-ups.