### PR TITLE
fix(coordination): only support separator rather than prefix and suffix

### DIFF
--- a/helpers/config.py
+++ b/helpers/config.py
@@ -204,11 +204,8 @@ class Config:
         self.BOT_DB_NAME = str(os.getenv('BOT_DB_NAME', ''))
 
         # Coordination
-        self.COORDINATION_CALLSIGN_PREFIX = os.getenv(
-            'COORDINATION_CALLSIGN_PREFIX', ''
-        )
-        self.COORDINATION_CALLSIGN_SUFFIX = os.getenv(
-            'COORDINATION_CALLSIGN_SUFFIX', ':'
+        self.COORDINATION_CALLSIGN_SEPARATOR = os.getenv(
+            'COORDINATION_CALLSIGN_SEPARATOR', '|'
         )
         self.COORDINATION_ALLOWED_CIDS = set(
             map(


### PR DESCRIPTION
Removes the support for COORDINATION_CALLSIGN_PREFIX.

Simplify the code, and stop dealing with prefixes when we do not use them.
