### PR TITLE
fix(roles): integrate member update and check for modified nicks

### DIFF
--- a/cogs/coordination.py
+++ b/cogs/coordination.py
@@ -103,6 +103,14 @@ class CoordinationCog(commands.Cog):
         await self._clean_up()
         logger.info('Stopped updating cache and attempted restoring existing members')
 
+    async def has_modified_nick(self, member: discord.Member) -> bool:
+        """Check if a member has a modified nickname"""
+        return (
+            member.nick is not None
+            and self._callsign_separator in member.nick
+            and self._member_cache.get(member.id) is not None
+        )
+
     async def _clean_up(self):
         ids = self._member_cache.get_member_ids()
         members = self._bot.get_all_members()

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+
+class ExpectedMixin:
+    """Base mixin for all expected exceptions."""
+
+
+class UnexpectedMixin:
+    """Base mixin for all unexpected exceptions."""
+
+
+class GuildNotFound(Exception, UnexpectedMixin):
+    """Exception raised when a guild is not found."""
+
+    def __init__(self, guild_id: int, payload: Any):
+        super().__init__()
+        self.guild_id = guild_id
+        self.payload = payload
+
+    def __str__(self):
+        """Return a string representation of the exception."""
+        return f'Guild with ID {self.guild_id} not found.'


### PR DESCRIPTION
Puts the entire roles loop into the roles cog, allowing us to disable it
when necessary for debugging. Attempts to fix #133.

fix(roles): add additional reasons to understand flow

Part of the problem is that we have two different mechanisms for
updating VATSIM and subdivision role assignment. Plus, both of these
have subtly different implementations for what a subdivision member is.

This adds additional reasons to those in `on_member_update`, while
providing structlog-implementation to `cogs/roles.py`, and some minor
fixes to `cogs/tasks.py`.
