### PR TITLE
docs(rules): Proof Reading and Typos

### DIFF
--- a/messages/rules.md
+++ b/messages/rules.md
@@ -1,22 +1,22 @@
 
 :bookmark: VATSIM Scandinavia provide a Discord server for its members. This server may however be freely used by any member of VATSIM Scandinavia or its parent organizations, who adheres to the following rules:
 
-:one: Treat each other with mutual respect. Don't threat, harass or belittle other members
+:one: Treat each other with mutual respect. Don't threaten, harass or belittle other members.
 
-:two: Sharing of illegal information, such as information about pirated software, is strictly prohibited
+:two: Sharing of illegal information, such as information about pirated software, is strictly prohibited.
 
-:three: Avoid unneccessary noises in voice channels, that might be to annoyance for others
+:three: Avoid unnecessary noises in voice channels, that might be to annoyance for others.
 
-:four: Adhere to instrcutions from the staff. Staff members is spotted by their visible rank
+:four: Adhere to instructions from the staff. Staff members can be spotted by their visible rank.
 
-:five: Do not enter any of the training department rooms unless you have a scheduled training or checkout. Use the 'Waiting room' if you have a planned session. Adjacent controllers may enter for coordination
+:five: Do not enter any of the training department rooms unless you have a scheduled training or checkout. Use the 'Waiting room' if you have a planned session. Adjacent controllers may enter for coordination.
 
-:six: Do not use any of the ATC Coordination rooms, named after the sector, unless you are controlling, or coordinating with adjacent controllers
+:six: Do not use any of the ATC Coordination rooms, named after the sector, unless you are controlling or coordinating with adjacent controllers.
 
-:seven: Use PPT (Push to talk) setting in ATC voice channels, the 'voice activity' option might be turned off to avoid disturbances
+:seven: Use PTT (Push to talk) setting in ATC voice channels, the 'voice activity' option should be turned off to avoid disturbances.
 
-:eight: Please post voice chat releated messages in the respective voice text channel instead of main channels
+:eight: Please post voice chat related messages in the respective voice text channel instead of main channels.
 
-:nine: Members being idle for more than 30 minutes will be moved to the 'Away' channel
+:nine: Members being idle for more than 30 minutes will be moved to the 'Away' channel.
 
 :one::zero: Do not stream Discord audio without permission from everyone present; this includes people that join while you are streaming.


### PR DESCRIPTION
Fixed some typos in the rules channel.

Cleaned some punctuation up to make it more readable. 