### PR TITLE
fix(roles): use laptop rather than tone-dependant technologist

### DIFF
--- a/messages/countries.md
+++ b/messages/countries.md
@@ -14,4 +14,4 @@
 
 :earth_africa: Access to ECFMP channel for flow measures, etc.
 :airplane: Access to Pilot Training channels
-:technologist: Access to tech channel to collaborate with Tech
+:computer: Access to tech channel to collaborate with Tech


### PR DESCRIPTION
As users can have different tones selected, using technologist requires
a different way of handling emojis which would extend the scope
somewhat.
