### PR TITLE
Introduce thread based staffing

### DIFF
--- a/cogs/fastapi.py
+++ b/cogs/fastapi.py
@@ -88,14 +88,19 @@ class FastAPICog(commands.Cog):
             if staffing.get('message_id'):
                 raise HTTPException(status_code=500, detail='Staffing already setup')
 
-            use_threads = staffing.get('use_threads', False) or staffing.get('is_thread', False)
+            use_threads = staffing.get('use_threads', False) or staffing.get(
+                'is_thread', False
+            )
 
             if use_threads:
                 # Thread-based staffing
-                parent_channel = self.bot.get_channel(int(staffing.get('channel_id', 0)))
+                parent_channel = self.bot.get_channel(
+                    int(staffing.get('channel_id', 0))
+                )
                 if not parent_channel:
                     raise HTTPException(
-                        status_code=500, detail='Parent channel not found for thread creation.'
+                        status_code=500,
+                        detail='Parent channel not found for thread creation.',
                     )
 
                 event = staffing.get('event', {})
@@ -117,13 +122,13 @@ class FastAPICog(commands.Cog):
                 # Store both message_id (from thread) and thread_id
                 response = await self.api_helper.patch_data(
                     f'staffings/{id}/update',
-                    {'message_id': thread_message.id, 'thread_id': thread.id}
+                    {'message_id': thread_message.id, 'thread_id': thread.id},
                 )
             else:
                 # Channel-based staffing
                 channel = self.bot.get_channel(int(staffing.get('channel_id', 0)))
                 if not channel:
-                     raise HTTPException(
+                    raise HTTPException(
                         status_code=500, detail='Channel not found for staffing setup.'
                     )
                 message = await channel.send(content=staffing_msg)

--- a/cogs/fastapi.py
+++ b/cogs/fastapi.py
@@ -122,6 +122,10 @@ class FastAPICog(commands.Cog):
             else:
                 # Channel-based staffing
                 channel = self.bot.get_channel(int(staffing.get('channel_id', 0)))
+                if not channel:
+                     raise HTTPException(
+                        status_code=500, detail='Channel not found for staffing setup.'
+                    )
                 message = await channel.send(content=staffing_msg)
                 await message.pin()
 

--- a/cogs/staffings.py
+++ b/cogs/staffings.py
@@ -69,13 +69,6 @@ class StaffingCog(commands.Cog):
                 ephemeral=True,
             )
             return
-        except discord.NotFound as e:
-            await ctx.send(
-                f'{ctx.author.mention} Error: Channel/thread or message not found. {e}',
-                delete_after=5,
-                ephemeral=True,
-            )
-            return
 
         await message.edit(content=staffing_msg)
         await ctx.send(
@@ -126,13 +119,6 @@ class StaffingCog(commands.Cog):
             except ValueError as e:
                 await ctx.send(
                     f'{ctx.author.mention} Error: {e}',
-                    delete_after=5,
-                    ephemeral=True,
-                )
-                return
-            except discord.NotFound as e:
-                await ctx.send(
-                    f'{ctx.author.mention} Error: Channel/thread or message not found. {e}',
                     delete_after=5,
                     ephemeral=True,
                 )

--- a/cogs/staffings.py
+++ b/cogs/staffings.py
@@ -59,7 +59,10 @@ class StaffingCog(commands.Cog):
         title = event.get('title', '')
 
         try:
-            _, message = await self.staffing_async._resolve_staffing_channel_and_message(
+            (
+                _,
+                message,
+            ) = await self.staffing_async._resolve_staffing_channel_and_message(
                 self.bot, staffing
             )
         except ValueError as e:
@@ -113,7 +116,10 @@ class StaffingCog(commands.Cog):
                 return
 
             try:
-                channel_or_thread, _ = await self.staffing_async._resolve_staffing_channel_and_message(
+                (
+                    channel_or_thread,
+                    _,
+                ) = await self.staffing_async._resolve_staffing_channel_and_message(
                     self.bot, staffing
                 )
             except ValueError as e:
@@ -175,7 +181,8 @@ class StaffingCog(commands.Cog):
                 )
             else:
                 staffing = next(
-                    (s for s in staffings if s.get('channel_id') == ctx.channel.id), None
+                    (s for s in staffings if s.get('channel_id') == ctx.channel.id),
+                    None,
                 )
 
             if not staffing:
@@ -218,7 +225,8 @@ class StaffingCog(commands.Cog):
                 )
             else:
                 staffing = next(
-                    (s for s in staffings if s.get('channel_id') == ctx.channel.id), None
+                    (s for s in staffings if s.get('channel_id') == ctx.channel.id),
+                    None,
                 )
 
             if not staffing:

--- a/helpers/staffing_async.py
+++ b/helpers/staffing_async.py
@@ -153,7 +153,9 @@ class StaffingAsync:
             ValueError: If required IDs are missing or channel/thread/message not found.
 
         """
-        use_threads = staffing.get('use_threads', False) or staffing.get('is_thread', False)
+        use_threads = staffing.get('use_threads', False) or staffing.get(
+            'is_thread', False
+        )
         message_id = staffing.get('message_id', 0)
 
         if not message_id:
@@ -172,7 +174,9 @@ class StaffingAsync:
             try:
                 message = await thread.fetch_message(int(message_id))
             except discord.NotFound as err:
-                msg = 'Message with ID {} not found in thread {}.'.format(message_id, thread_id)
+                msg = 'Message with ID {} not found in thread {}.'.format(
+                    message_id, thread_id
+                )
                 raise ValueError(msg) from err
 
             return thread, message
@@ -189,7 +193,9 @@ class StaffingAsync:
         try:
             message = await channel.fetch_message(int(message_id))
         except discord.NotFound as err:
-            msg = 'Message with ID {} not found in channel {}.'.format(message_id, channel_id)
+            msg = 'Message with ID {} not found in channel {}.'.format(
+                message_id, channel_id
+            )
             raise ValueError(msg) from err
 
         return channel, message
@@ -268,9 +274,10 @@ class StaffingAsync:
             raise ValueError
 
         try:
-            channel_or_thread, message = await self._resolve_staffing_channel_and_message(
-                bot, staffing
-            )
+            (
+                channel_or_thread,
+                message,
+            ) = await self._resolve_staffing_channel_and_message(bot, staffing)
         except (ValueError, discord.NotFound) as e:
             print(f'Error resolving staffing channel/message: {e}')
             raise

--- a/helpers/staffing_async.py
+++ b/helpers/staffing_async.py
@@ -145,13 +145,13 @@ class StaffingAsync:
     async def _resolve_staffing_channel_and_message(self, bot, staffing):
         """
         Resolve the channel/thread and message for a staffing.
-        
+
         Returns:
-            tuple: (channel_or_thread, message) or (None, None) if not found
-        
+            tuple: (channel_or_thread, message)
+
         Raises:
-            ValueError: If required IDs are missing
-            discord.NotFound: If channel/thread or message not found
+            ValueError: If required IDs are missing or channel/thread/message not found.
+
         """
         use_threads = staffing.get('use_threads', False) or staffing.get('is_thread', False)
         message_id = staffing.get('message_id', 0)
@@ -166,33 +166,33 @@ class StaffingAsync:
 
             thread = bot.get_channel(int(thread_id))
             if not thread:
-                raise discord.NotFound(f'Thread with ID {thread_id} not found.', None)
+                msg = 'Thread with ID {} not found.'.format(thread_id)
+                raise ValueError(msg)
 
             try:
                 message = await thread.fetch_message(int(message_id))
-            except discord.NotFound:
-                raise discord.NotFound(
-                    f'Message with ID {message_id} not found in thread {thread_id}.', None
-                )
+            except discord.NotFound as err:
+                msg = 'Message with ID {} not found in thread {}.'.format(message_id, thread_id)
+                raise ValueError(msg) from err
 
             return thread, message
-        else:
-            channel_id = staffing.get('channel_id', 0)
-            if not channel_id:
-                raise ValueError('Channel ID not found for channel-based staffing.')
 
-            channel = bot.get_channel(int(channel_id))
-            if not channel:
-                raise discord.NotFound(f'Channel with ID {channel_id} not found.', None)
+        channel_id = staffing.get('channel_id', 0)
+        if not channel_id:
+            raise ValueError('Channel ID not found for channel-based staffing.')
 
-            try:
-                message = await channel.fetch_message(int(message_id))
-            except discord.NotFound:
-                raise discord.NotFound(
-                    f'Message with ID {message_id} not found in channel {channel_id}.', None
-                )
+        channel = bot.get_channel(int(channel_id))
+        if not channel:
+            msg = 'Channel with ID {} not found.'.format(channel_id)
+            raise ValueError(msg)
 
-            return channel, message
+        try:
+            message = await channel.fetch_message(int(message_id))
+        except discord.NotFound as err:
+            msg = 'Message with ID {} not found in channel {}.'.format(message_id, channel_id)
+            raise ValueError(msg) from err
+
+        return channel, message
 
     async def _book(self, ctx, staffing, position, section):
         try:

--- a/helpers/staffing_async.py
+++ b/helpers/staffing_async.py
@@ -168,15 +168,13 @@ class StaffingAsync:
 
             thread = bot.get_channel(int(thread_id))
             if not thread:
-                msg = 'Thread with ID {} not found.'.format(thread_id)
+                msg = f'Thread with ID {thread_id} not found.'
                 raise ValueError(msg)
 
             try:
                 message = await thread.fetch_message(int(message_id))
             except discord.NotFound as err:
-                msg = 'Message with ID {} not found in thread {}.'.format(
-                    message_id, thread_id
-                )
+                msg = f'Message with ID {message_id} not found in thread {thread_id}.'
                 raise ValueError(msg) from err
 
             return thread, message
@@ -187,15 +185,13 @@ class StaffingAsync:
 
         channel = bot.get_channel(int(channel_id))
         if not channel:
-            msg = 'Channel with ID {} not found.'.format(channel_id)
+            msg = f'Channel with ID {channel_id} not found.'
             raise ValueError(msg)
 
         try:
             message = await channel.fetch_message(int(message_id))
         except discord.NotFound as err:
-            msg = 'Message with ID {} not found in channel {}.'.format(
-                message_id, channel_id
-            )
+            msg = f'Message with ID {message_id} not found in channel {channel_id}.'
             raise ValueError(msg) from err
 
         return channel, message


### PR DESCRIPTION
## Summary by Sourcery

Add support for thread-based staffings alongside existing channel-based behavior, including setup, lookup, and reset flows.

New Features:
- Allow staffing setup to create and track Discord threads per staffing using stored thread IDs.
- Support booking and unbooking commands executed from either the parent channel or the associated thread.

Bug Fixes:
- Prevent errors when handling staffing events that previously assumed an event string instead of an object.

Enhancements:
- Enable staffing refresh and autoreset logic to operate on either channels or threads based on configuration.
- Add automatic, date-based thread naming for staffing threads created during setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staffing now supports Discord threads alongside channels.
  * Threads are auto-named from event info (with sensible fallback), thread messages are pinned and set to a 7-day auto-archive.
  * Commands (book, unbook, refresh, reset) detect and operate in threads or channels.

* **Bug Fixes / Improvements**
  * Improved resolution and error handling when channels, threads, or messages are missing.
  * Reset/refresh flows reliably target the correct channel or thread and surface clear, ephemeral errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->