### PR TITLE
Added manual FAQ bot trigger command

### DIFF
--- a/cogs/faq.py
+++ b/cogs/faq.py
@@ -37,10 +37,10 @@ class FAQ(commands.Cog):
             )
             return
 
+        await interaction.response.send_message('FAQ sent!', ephemeral=True)
         await send_faq_embed(
             interaction.channel, interaction.user.mention, topic, self.faqs[topic]
         )
-        await interaction.response.send_message('FAQ sent!', ephemeral=True)
 
     @faq.autocomplete('topic')
     async def faq_autocomplete(
@@ -48,7 +48,7 @@ class FAQ(commands.Cog):
     ) -> list[app_commands.Choice[str]]:
         return [
             app_commands.Choice(name=topic, value=topic)
-            for topic in self.faqs.keys()
+            for topic in self.faqs
             if current.lower() in topic.lower()
         ]
 

--- a/cogs/faq.py
+++ b/cogs/faq.py
@@ -3,6 +3,7 @@ import time
 from typing import Any
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from helpers.config import config
@@ -25,6 +26,31 @@ class FAQ(commands.Cog):
 
         # Store (channel_id, topic): last_reply_time
         self.recent_replies: dict[tuple[int, str], float] = {}
+
+    @app_commands.command(name='faq', description='Manually call FAQ responses')
+    @app_commands.describe(topic='The FAQ topic to display')
+    async def faq(self, interaction: discord.Interaction, topic: str):
+        if topic not in self.faqs:
+            await interaction.response.send_message(
+                f'Invalid topic. Available topics: {", ".join(self.faqs.keys())}',
+                ephemeral=True,
+            )
+            return
+
+        await send_faq_embed(
+            interaction.channel, interaction.user.mention, topic, self.faqs[topic]
+        )
+        await interaction.response.send_message('FAQ sent!', ephemeral=True)
+
+    @faq.autocomplete('topic')
+    async def faq_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        return [
+            app_commands.Choice(name=topic, value=topic)
+            for topic in self.faqs.keys()
+            if current.lower() in topic.lower()
+        ]
 
     def _load_faq(self, filename: str) -> str:
         try:


### PR DESCRIPTION
Supplies the requested feature (that is still not decided upon) #179 

Using the '/faq' command one is able to call one of the 3 options that the faq bot currently responds to. 
Autocompletion for the faq command for the 3 options is implemented. 
Writes an ephemeral trigger message to ensure that the trigger-er knows they have triggered it.


Does NOT currently prevent the bot from sending the message again within the hour as it does when automatically triggered

## Summary by Sourcery

New Features:
- Introduce a /faq slash command that lets users manually display specific FAQ topics with autocomplete support and ephemeral confirmation messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced `/faq` slash command to access frequently asked questions by topic.
  * Added autocomplete for topic selection that filters available FAQ topics as you type.
  * FAQ responses are sent ephemerally with a formatted embed and automatic confirmation message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->