### PR TITLE
fix(staffing): force mentions of controllers

### DIFF
--- a/helpers/staffing_async.py
+++ b/helpers/staffing_async.py
@@ -194,7 +194,10 @@ class StaffingAsync:
 
         channel = bot.get_channel(int(staffing.get('channel_id', 0)))
         message = await channel.fetch_message(int(staffing.get('message_id', 0)))
-        await message.edit(content=staffing_msg)
+        await message.edit(
+            content=staffing_msg,
+            allowed_mentions=discord.AllowedMentions(users=True)
+        )
 
         if reset:
             event = staffing.get('event', {})

--- a/helpers/staffing_async.py
+++ b/helpers/staffing_async.py
@@ -1,5 +1,7 @@
 # Linting ignored due to staffing module getting a major refactor.
 import asyncio
+import discord
+
 from collections import defaultdict
 from datetime import datetime
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Configure staffing message edits to use Discord allowed mentions with users enabled to control which mentions are processed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of user mentions when staffing messages are edited so mentions display correctly and notify users as expected.
  * Ensures updated staffing posts preserve mention behavior when updated, reducing missed notifications and confusion for staff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->