### PR TITLE
fix: members without roles got many logs hits

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -126,7 +126,7 @@ class AdminCog(commands.Cog):
     )
     @app_commands.checks.has_any_role(*config.STAFF_ROLES)
     async def delete(self, interaction: discord.Interaction, amount: int):
-        ctx = await Handler.get_context(self, self.bot, interaction)
+        ctx = await Handler.get_context(self.bot, interaction)
 
         if config.DEBUG:
             try:

--- a/cogs/member.py
+++ b/cogs/member.py
@@ -15,7 +15,7 @@ class MemberCog(commands.Cog):
     @app_commands.command(name='test', description='Function sends example embed.')
     @app_commands.checks.has_any_role(*config.STAFF_ROLES)
     async def test(self, interaction: discord.Interaction):
-        ctx = await Handler.get_context(self, self.bot, interaction)
+        ctx = await Handler.get_context(self.bot, interaction)
 
         if config.DEBUG:
             message = embed(title='test', description='test')
@@ -28,7 +28,7 @@ class MemberCog(commands.Cog):
     @app_commands.command(name='metar', description='Get METAR for an airport')
     async def metar(self, interaction: discord.Interaction, airport: str) -> None:
         """Function send METAR of specified airport."""
-        ctx = await Handler.get_context(self, self.bot, interaction)
+        ctx = await Handler.get_context(self.bot, interaction)
 
         async with aiohttp.ClientSession() as session:
             async with session.get(f'http://metar.vatsim.net/{airport}') as resp:

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -134,14 +134,6 @@ class RolesCog(commands.Cog):
             # Check if the user has the VATSIM member role, if not clear all managed roles and skip.
             cid = self.handler.get_cid(user)
             if cid is None:
-                await self.cleanup_membership_roles(
-                    user,
-                    config.ROLE_REASONS['no_vatsim_role'],
-                    include_vatsca=True,
-                )
-                return
-
-            if not cid:
                 raise ValueError("No CID found in member's nickname.")
 
             mentor_buddy_info = self.get_mentor_roles(cid, roles_data)

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -197,7 +197,7 @@ class RolesCog(commands.Cog):
 
         except ValueError as e:
             logger.warning(
-                'Failed to process roles, probably because we could not get CID due ValueError: will remove any roles',
+                'Failed to process memeber role due to being unable to extract CID; cleaning managed roles.',
                 name=user.name,
                 nick=user.nick,
                 error=e,

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -134,7 +134,10 @@ class RolesCog(commands.Cog):
             # Check if the user has the VATSIM member role, if not clear all managed roles and skip.
             cid = self.handler.get_cid(user)
             if cid is None:
-                raise ValueError("No CID found in member's nickname.")
+                await self.cleanup_membership_roles(
+                    user, config.ROLE_REASONS['no_cid'], include_vatsca=True
+                )
+                return
 
             mentor_buddy_info = self.get_mentor_roles(cid, roles_data)
             should_be_examiner, examiner_firs = self.get_examiner_roles(
@@ -197,13 +200,13 @@ class RolesCog(commands.Cog):
 
         except ValueError as e:
             logger.warning(
-                'Failed to process memeber role due to being unable to extract CID; cleaning managed roles.',
+                'Stopped to process memeber role due to being unable to extract CID; cleaning managed roles.',
                 name=user.name,
                 nick=user.nick,
                 error=e,
             )
             await self.cleanup_membership_roles(
-                user, config.ROLE_REASONS['no_cid'], include_vatsca=True
+                user, config.ROLE_REASONS['unknown_cid'], include_vatsca=True
             )
 
         except Exception:

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -131,7 +131,16 @@ class RolesCog(commands.Cog):
 
         """
         try:
+            # Check if the user has the VATSIM member role, if not clear all managed roles and skip.
             cid = self.handler.get_cid(user)
+            if cid is None:
+                await self.cleanup_membership_roles(
+                    user,
+                    config.ROLE_REASONS['no_vatsim_role'],
+                    include_vatsca=True,
+                )
+                return
+
             if not cid:
                 raise ValueError("No CID found in member's nickname.")
 
@@ -201,22 +210,9 @@ class RolesCog(commands.Cog):
                 nick=user.nick,
                 error=e,
             )
-            if mentor_role in user.roles:
-                await user.remove_roles(
-                    mentor_role, reason=config.ROLE_REASONS['no_cid']
-                )
-            if buddy_role in user.roles:
-                await user.remove_roles(
-                    buddy_role, reason=config.ROLE_REASONS['no_cid']
-                )
-            if training_staff_role in user.roles:
-                await user.remove_roles(
-                    training_staff_role, reason=config.ROLE_REASONS['no_cid']
-                )
-            if visitor_role in user.roles:
-                await user.remove_roles(
-                    visitor_role, reason=config.ROLE_REASONS['no_cid']
-                )
+            await self.cleanup_membership_roles(
+                user, config.ROLE_REASONS['no_cid'], include_vatsca=True
+            )
 
         except Exception:
             logger.exception('Error processing roles', name=user.name, nick=user.nick)
@@ -413,6 +409,45 @@ class RolesCog(commands.Cog):
                     config.ROLE_REASONS['training_add'],
                     config.ROLE_REASONS['training_remove'],
                 )
+
+    def _membership_role_ids(self, include_vatsca: bool = False) -> set[int]:
+        role_ids = {
+            config.MENTOR_ROLE,
+            config.BUDDY_ROLE,
+            config.TRAINING_STAFF_ROLE,
+            config.VISITOR_ROLE,
+        }
+
+        if include_vatsca:
+            role_ids.add(config.VATSCA_MEMBER_ROLE)
+
+        role_ids.update(int(role_id) for role_id in config.FIR_MENTORS.values())
+        role_ids.update(int(role_id) for role_id in config.FIR_BUDDIES.values())
+        role_ids.update(int(role_id) for role_id in config.FIR_EXAMINERS.values())
+        role_ids.update(
+            int(role_id)
+            for ratings in config.TRAINING_ROLES.values()
+            for role_id in ratings.values()
+        )
+        role_ids.update(
+            int(role_id) for role_id in config.CONTROLLER_FIR_ROLES.values()
+        )
+        role_ids.update(
+            int(role_id)
+            for ratings in config.RATING_FIR_DATA.values()
+            for role_id in ratings.values()
+        )
+
+        return {role_id for role_id in role_ids if role_id}
+
+    async def cleanup_membership_roles(
+        self, user: discord.Member, reason: str, include_vatsca: bool = False
+    ) -> None:
+        role_ids = self._membership_role_ids(include_vatsca=include_vatsca)
+        roles_to_remove = [role for role in user.roles if role.id in role_ids]
+
+        if roles_to_remove:
+            await user.remove_roles(*roles_to_remove, reason=reason)
 
     async def update_fir_atc_roles(self, user, cid, atc_activity_data):
         """Update FIR-specific ATC roles based on activity and rating."""
@@ -617,10 +652,17 @@ class RolesCog(commands.Cog):
             )
             return
 
-        # Extract cid from nickname, exit early if not found
-        cid = self.handler.get_cid(after)
-
         try:
+            # Extract CID from nickname, clearing managed roles if the member is no longer eligible.
+            cid = self.handler.get_cid(after)
+            if cid is None:
+                await self.cleanup_membership_roles(
+                    after,
+                    config.ROLE_REASONS['no_vatsim_role'],
+                    include_vatsca=True,
+                )
+                return
+
             api_data = await self.handler.get_division_members()
 
             should_have_vatsca = any(
@@ -659,6 +701,17 @@ class RolesCog(commands.Cog):
 
             if tasks:
                 await asyncio.gather(*tasks)
+
+        except ValueError as e:
+            logger.warning(
+                'Failed to process member update due to invalid or missing CID; cleaning managed roles.',
+                name=after.name,
+                nick=after.nick,
+                error=e,
+            )
+            await self.cleanup_membership_roles(
+                after, config.ROLE_REASONS['no_cid'], include_vatsca=True
+            )
 
         # TODO(thor): Replace with either custom exceptions or find out how to move them out to the core handler
         except discord.Forbidden as e:

--- a/cogs/staffings.py
+++ b/cogs/staffings.py
@@ -49,7 +49,7 @@ class StaffingCog(commands.Cog):
     @app_commands.autocomplete(staffing=avail_title_autocomplete)
     @app_commands.checks.has_any_role(*config.STAFF_ROLES)
     async def refreshevent(self, interaction: discord.Interaction, staffing: int):
-        ctx = await Handler.get_context(self, self.bot, interaction)
+        ctx = await Handler.get_context(self.bot, interaction)
 
         staffing, staffing_msg = await self.staffing_async._generate_staffing_message(
             staffing
@@ -75,7 +75,7 @@ class StaffingCog(commands.Cog):
     @app_commands.autocomplete(staffing=avail_title_autocomplete)
     @app_commands.checks.has_any_role(*config.STAFF_ROLES)
     async def manreset(self, interaction: discord.Integration, staffing: int):
-        ctx = await Handler.get_context(self, self.bot, interaction)
+        ctx = await Handler.get_context(self.bot, interaction)
 
         try:
             staffing = await self.api_helper._fetch_data(f'staffings/{staffing}')
@@ -131,7 +131,7 @@ class StaffingCog(commands.Cog):
         position: str,
         section: str | None = None,
     ):
-        ctx = await Handler.get_context(self, self.bot, interaction)
+        ctx = await Handler.get_context(self.bot, interaction)
         user_id = ctx.author.id
 
         try:
@@ -175,7 +175,7 @@ class StaffingCog(commands.Cog):
         position: str | None = None,
         section: str | None = None,
     ):
-        ctx = await Handler.get_context(self, self.bot, interaction)
+        ctx = await Handler.get_context(self.bot, interaction)
         try:
             staffings = await self.api_helper._fetch_data('staffings')
             staffing = next(

--- a/cogs/station_prefix.py
+++ b/cogs/station_prefix.py
@@ -274,6 +274,10 @@ class StationPrefixCog(commands.Cog):
                 cid = self._handler.get_cid(member)
                 name = self._handler.get_name(member)
 
+            if cid is None:
+                # No CID found in nickname, and no modification record: nothing we can do
+                return
+
             log = log.bind(cid=cid)
 
             if not cid and not name:

--- a/cogs/tasks.py
+++ b/cogs/tasks.py
@@ -94,7 +94,7 @@ class TasksCog(commands.Cog):
             cid = self.handler.get_cid(user)
             if cid is None:
                 raise ValueError(
-                    'Unrachable: A user should not have access to a channel without vatsim member role.'
+                    'Unreachable: A user should not have access to a channel without vatsim member role.'
                 )
             if not cid:
                 raise ValueError("No CID found in member's nickname.")

--- a/cogs/tasks.py
+++ b/cogs/tasks.py
@@ -96,8 +96,6 @@ class TasksCog(commands.Cog):
                 raise ValueError(
                     'Unreachable: A user should not have access to a channel without vatsim member role.'
                 )
-            if not cid:
-                raise ValueError("No CID found in member's nickname.")
 
             is_vatsca_member = (
                 cid in member_map

--- a/cogs/tasks.py
+++ b/cogs/tasks.py
@@ -92,6 +92,10 @@ class TasksCog(commands.Cog):
         """
         try:
             cid = self.handler.get_cid(user)
+            if cid is None:
+                raise ValueError(
+                    'Unrachable: A user should not have access to a channel without vatsim member role.'
+                )
             if not cid:
                 raise ValueError("No CID found in member's nickname.")
 

--- a/cogs/tasks.py
+++ b/cogs/tasks.py
@@ -93,9 +93,10 @@ class TasksCog(commands.Cog):
         try:
             cid = self.handler.get_cid(user)
             if cid is None:
-                raise ValueError(
-                    'Unreachable: A user should not have access to a channel without vatsim member role.'
+                await user.remove_roles(
+                    vatsca_role, reason=config.ROLE_REASONS['no_cid']
                 )
+                return
 
             is_vatsca_member = (
                 cid in member_map
@@ -119,7 +120,7 @@ class TasksCog(commands.Cog):
         except ValueError:
             if vatsca_role in user.roles:
                 await user.remove_roles(
-                    vatsca_role, reason=config.ROLE_REASONS['no_cid']
+                    vatsca_role, reason=config.ROLE_REASONS['unknown_cid']
                 )
 
         except Exception as e:

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -65,6 +65,7 @@ class Config:
             'vatsca_add': 'Member is now part of VATSCA',
             'vatsca_remove': 'Member is no longer part of VATSCA',
             'no_cid': 'User does not have a VATSIM ID in his/her nickname.',
+            'no_vatsim_role': 'User does not have the VATSIM member role.',
             'no_auth': 'User did not authenticate via the Community Website',
             'mentor_add': 'Member is now a mentor',
             'mentor_remove': 'Member is no longer a mentor',

--- a/helpers/handler.py
+++ b/helpers/handler.py
@@ -26,9 +26,8 @@ class Handler:
     def __init__(self) -> None:
         pass
 
-    async def get_context(
-        self, bot, interaction: discord.Interaction
-    ) -> commands.Context:
+    @staticmethod
+    async def get_context(bot, interaction: discord.Interaction) -> commands.Context:
         """
         Helper function to get context from interaction
         :return:
@@ -51,7 +50,8 @@ class Handler:
             )
         return True
 
-    async def get_division_members(self) -> list[DivisionMember]:
+    @classmethod
+    async def get_division_members(cls) -> list[DivisionMember]:
         """
         Fetch all division members from the API with pagination.
         :return:
@@ -66,7 +66,7 @@ class Handler:
             while url:
                 # We'd like to capture any non-valid responses sooner rather than earlier
                 try:
-                    data, url = await self._fetch_page(session, url)
+                    data, url = await cls._fetch_page(session, url)
                 except Exception as e:
                     raise VATSIMDivisionMemberFetchException from e
 
@@ -78,7 +78,8 @@ class Handler:
 
         return result
 
-    async def _fetch_page(self, session: aiohttp.ClientSession, url):
+    @staticmethod
+    async def _fetch_page(session: aiohttp.ClientSession, url):
         """
         Fetch data from a single page and return the next URL if available.
 
@@ -104,14 +105,24 @@ class Handler:
 
             return data, next_url
 
-    def get_cid(self, member: discord.Member):
+    @staticmethod
+    def get_cid(member: discord.Member) -> int | None:
         """
         Get CID based on VATSIM Discord member.
 
         Args:
             member: The Discord guild member.
 
+        Returns:
+            None if the member does not have the VATSIM member role, otherwise the CID.
+
+        Raises:
+            ValueError: If the member has the VATSIM member role but a valid CID cannot be extracted from their nickname.
+
         """
+        if config.VATSIM_MEMBER_ROLE not in [role.id for role in member.roles]:
+            return None
+
         if member.nick is None:
             raise ValueError
 
@@ -138,7 +149,8 @@ class Handler:
 
         return cid[-1]
 
-    def get_name(self, member: discord.Member) -> str | None:
+    @staticmethod
+    def get_name(member: discord.Member) -> str | None:
         """
         Get presentation name based on VATSIM Discord member.
 

--- a/helpers/handler.py
+++ b/helpers/handler.py
@@ -50,8 +50,8 @@ class Handler:
             )
         return True
 
-    @classmethod
-    async def get_division_members(cls) -> list[DivisionMember]:
+    @staticmethod
+    async def get_division_members() -> list[DivisionMember]:
         """
         Fetch all division members from the API with pagination.
         :return:
@@ -66,7 +66,7 @@ class Handler:
             while url:
                 # We'd like to capture any non-valid responses sooner rather than earlier
                 try:
-                    data, url = await cls._fetch_page(session, url)
+                    data, url = await Handler._fetch_page(session, url)
                 except Exception as e:
                     raise VATSIMDivisionMemberFetchException from e
 
@@ -114,13 +114,17 @@ class Handler:
             member: The Discord guild member.
 
         Returns:
-            None if the member does not have the VATSIM member role, otherwise the CID.
+            None if the member has a roles collection and does not have the VATSIM
+            member role, otherwise the CID.
 
         Raises:
             ValueError: If the member has the VATSIM member role but a valid CID cannot be extracted from their nickname.
 
         """
-        if config.VATSIM_MEMBER_ROLE not in [role.id for role in member.roles]:
+        roles = getattr(member, 'roles', None)
+        if roles is not None and not any(
+            getattr(role, 'id', role) == config.VATSIM_MEMBER_ROLE for role in roles
+        ):
             return None
 
         if member.nick is None:

--- a/helpers/staffing_async.py
+++ b/helpers/staffing_async.py
@@ -121,7 +121,7 @@ class StaffingAsync:
 
     async def _book(self, ctx, staffing, position, section):
         try:
-            cid = Handler.get_cid(self, ctx.author)
+            cid = Handler.get_cid(ctx.author)
 
             sections_map = {
                 (staffing.get('section_1_title') or '').lower(): '1',

--- a/helpers/staffing_async.py
+++ b/helpers/staffing_async.py
@@ -127,7 +127,7 @@ class StaffingAsync:
 
             if cid is None:
                 logger.warning(
-                    'User attempted to book without a CID.', user=ctx.author.id
+                    'User attempted to book without a CID', user=ctx.author.id
                 )
                 return
 

--- a/helpers/staffing_async.py
+++ b/helpers/staffing_async.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from helpers.api import APIHelper
 from helpers.handler import Handler
 
+logger = Handler.get_logger('StaffingAsync')
+
 
 class StaffingAsync:
     def __init__(self) -> None:
@@ -122,6 +124,12 @@ class StaffingAsync:
     async def _book(self, ctx, staffing, position, section):
         try:
             cid = Handler.get_cid(ctx.author)
+
+            if cid is None:
+                logger.warning(
+                    'User attempted to book without a CID.', user=ctx.author.id
+                )
+                return
 
             sections_map = {
                 (staffing.get('section_1_title') or '').lower(): '1',


### PR DESCRIPTION
This started as a small issue but grew in scope quickly. We now return None, when we know that there is not going to be a CID, to handle this more efficient. This also dragged in some other issues from the handler class. Should all be consistent now.

## Summary by Sourcery

Handle members without the VATSIM role more efficiently by skipping CID extraction and cleaning up all managed membership roles, while generalizing handler utilities and updating callers accordingly.

Bug Fixes:
- Prevent excessive logging and inconsistent role handling for members who lack the VATSIM member role or a valid CID in their nickname.

Enhancements:
- Introduce centralized helpers to compute and clean up all managed membership roles, including optional VATSCA roles.
- Refine the Handler API by making common helpers static/class methods and updating all call sites to use them consistently.
- Improve member update error handling by catching CID-related errors, logging them clearly, and cleaning up managed roles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More consistent cleanup of managed membership roles (including VATSCA) when users lack or have invalid VATSIM credentials, preventing stale assignments.
  * Member updates now stop processing when CID is missing, avoiding incorrect bindings and unwanted role changes.
  * Slash commands and staffing actions are more stable; context resolution is fixed and booking attempts are prevented when CID is unavailable.

* **Chores**
  * Added a clearer reason message for the "no VATSIM role" case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->