### PR TITLE
fix: error in getting logger

### DIFF
--- a/helpers/staffing_async.py
+++ b/helpers/staffing_async.py
@@ -3,10 +3,12 @@ import asyncio
 from collections import defaultdict
 from datetime import datetime
 
+import structlog
+
 from helpers.api import APIHelper
 from helpers.handler import Handler
 
-logger = Handler.get_logger('StaffingAsync')
+logger = structlog.stdlib.get_logger()
 
 
 class StaffingAsync:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix logger initialization in the staffing async helper to use a valid structlog logger instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging system dependencies and configuration to enhance system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->