### PR TITLE
fix(messages): correct grammar for channel reset

### DIFF
--- a/cogs/staffings.py
+++ b/cogs/staffings.py
@@ -105,7 +105,7 @@ class StaffingCog(commands.Cog):
 
             channel = self.bot.get_channel(int(staffing.get('channel_id', 0)))
 
-            await channel.send('The chat is being automatic reset!')
+            await channel.send('The chat is being automatically reset!')
             await asyncio.sleep(5)
             await channel.purge(limit=None, check=lambda msg: not msg.pinned)
 

--- a/helpers/staffing_async.py
+++ b/helpers/staffing_async.py
@@ -211,7 +211,7 @@ class StaffingAsync:
             title = event.get('title', '')
             print(f'Started autoreset of {title} at {datetime.now().isoformat()!s}')
 
-            await channel.send('The chat is being automatic reset!')
+            await channel.send('The chat is being automatically reset!')
             await asyncio.sleep(5)
             await channel.purge(limit=None, check=lambda msg: not msg.pinned)
 


### PR DESCRIPTION
Update the message:

'The chat is being automatic reset!'
to
'The chat is being automatically reset!'

## Summary by Sourcery

Enhancements:
- Improve the grammar of the automated chat reset notification shown in channels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automatic reset notification messages for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vatsim-Scandinavia/discord-bot/pull/207)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->