### PR TITLE
fix: do not remove members from cache before reset

### DIFF
--- a/cogs/station_prefix.py
+++ b/cogs/station_prefix.py
@@ -211,13 +211,11 @@ class StationPrefixCog(commands.Cog):
             return
 
         original_nick = modified_member['nick']
-        # Remove the nickname first to avoid issue for those weird users who have higher permissions
-        # than the bot itself. This is an additional risk, but one we're fine to make.
         log.info(
             'Removing and restoring nick', stored_nick=original_nick, reason=reason
         )
-        await self._member_cache.remove_nickname(member.id)
         await member.edit(nick=original_nick, reason=reason)
+        await self._member_cache.remove_nickname(member.id)
 
     def _format_name(self, prefix: str, name: str | None, cid: int) -> str:
         """Format the name for the member's nickname"""


### PR DESCRIPTION
If discord has returns an error when we want to reset the nick, we remove the nick without the action being complete

This should fix #126 again

BEGIN_COMMIT_OVERRIDE
fix: discord errors while resetting nic, should no longer leave the station nick forever (#210)
END_COMMIT_OVERRIDE

## Summary by Sourcery

Bug Fixes:
- Prevent cached nicknames from being removed when Discord fails to reset a member's nickname.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the order of operations when restoring member nicknames to ensure proper functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vatsim-Scandinavia/discord-bot/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->